### PR TITLE
Going whole-hog with promises cleans stuff up

### DIFF
--- a/lib/update-user-modules.js
+++ b/lib/update-user-modules.js
@@ -1,43 +1,29 @@
 var Promise = require('promise')
 var semver = require('semver')
 
-var getModuleDetails = require('./get-module-details')
-var getNpmModules = require('./get-npm-modules')
-var getRecentCommit = require('./get-recent-commit')
-var pushToNpm = require('./push-commit-to-npm')
+var getModuleDetails = Promise.denodeify(require('./get-module-details'))
+var getNpmModules = Promise.denodeify(require('./get-npm-modules'))
+var getRecentCommit = Promise.denodeify(require('./get-recent-commit'))
+var pushToNpm = Promise.denodeify(require('./push-commit-to-npm'))
 
-module.exports = function UpdateUserModules(username, cb) {
-	getNpmModules(username, function(err, modules) {
-		var promises
-		if (err) {
-			console.log(new Date(), 'error getting module list from npm', err)
-		} else {
-			promises = modules.map(function(moduleName) {
-				return new Promise(function(resolve, reject) {
-					getModuleDetails(moduleName, function(err, module) {
-						if (err) {
-							resolve({ error: new Date(), module: moduleName, error: err })
-						} else {
-							getRecentCommit(module, function(err, commit) {
-								if (err) {
-									resolve({ error: new Date(), module: moduleName, error: err })
-								} else if (semver.gt(commit.version, module.version)) {
-									pushToNpm(commit, function(err) {
-										if (err) {
-											resolve({ error: new Date(), module: moduleName, error: err })
-										} else {
-											resolve({ updated: new Date(), module: moduleName })
-										}
-									})
-								} else {
-									resolve({ checked: new Date(), module: moduleName })
-								}
-							})
-						}
+module.exports = Promise.nodeify(function UpdateUserModules(username) {
+	return getNpmModules(username).then(function checkModuleVersions(modules) {
+		var promises = modules.map(function(moduleName) {
+			return getModuleDetails(moduleName).then(getRecentCommit).then(function checkCommitModuleVersion(commit) {
+				if (semver.gt(commit.version, module.version)) {
+					return pushToNpm(commit).then(function() {
+						return { updated: new Date(), module: moduleName }
 					})
-				})
+				} else {
+					return { checked: new Date(), module: moduleName }
+				}
+			}).catch(function errorUpdatingModule(err) {
+				return { module: moduleName, error: err }
 			})
-		}
-		Promise.all(promises).then(cb)
+		})
+		return Promise.all(promises)
+	}, function errorGettingNpmModules(err) {
+		console.log(new Date(), 'error getting module list from npm', err)
+		throw err
 	})
-}
+})


### PR DESCRIPTION
It gets rid of all the boilerplate error handling, among other things.

This also fixes a bug where the callback would never get called if
getNpmModules encountered an error.

I left in the console.log line, though it seems to me it would be
better for this module to not log anything, and let the outer layer
handle any output.
